### PR TITLE
Switch to forcing query_args to regenerate at render time on Post List widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** user, home, screen, dashboard, widgets  
 **Requires at least:** 4.5  
 **Tested up to:** 4.7  
-**Stable tag:** 0.8.1  
+**Stable tag:** 0.8.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -44,6 +44,9 @@ Yes. This plugin has it's own way of registering and supporting custom widgets. 
 
 ## Changelog ##
 
+### 0.8.2 ###
+* Switch to forcing query_args to regenerate at render time on Post List widgets
+
 ### 0.8.1 ###
 * Stability fixes and UI polish.
 
@@ -51,6 +54,9 @@ Yes. This plugin has it's own way of registering and supporting custom widgets. 
 * Initial release.
 
 ## Upgrade Notice ##
+
+### 0.8.2 ###
+* Switch to forcing query_args to regenerate at render time on Post List widgets
 
 ### 0.8.1 ###
 * Stability fixes and UI polish.

--- a/inc/class-user-home-screen-ajax.php
+++ b/inc/class-user-home-screen-ajax.php
@@ -316,8 +316,10 @@ class User_Home_Screen_Ajax {
 			];
 			$regen_args = $this->main->data->validate_widget_data( $regen_args_input );
 
-			// Override the saved query args.
-			$args['args']['query_args'] = $regen_args['args']['query_args'];
+			// Override the saved query args if we ended up with fresh args.
+			if ( ! empty( $regen_args['args']['query_args'] ) ) {
+				$args['args']['query_args'] = $regen_args['args']['query_args'];
+			}
 		}
 
 		// Modify the query args to include the new page.

--- a/inc/class-user-home-screen-ajax.php
+++ b/inc/class-user-home-screen-ajax.php
@@ -303,6 +303,23 @@ class User_Home_Screen_Ajax {
 
 		$args = $user_widgets[ $tab_id ][ $widget_id ];
 
+		// Force the query_args to get regenerated at render time to resolve
+		// any issues with the saved query_args in the DB being out of sync.
+		if ( ! empty( $args['args']['original_args'] ) ) {
+
+			// This is a rebuild of the original input args.
+			$regen_args_input = [
+				'id'   => $widget_id,
+				'tab'  => $tab_id,
+				'type' => 'post-list',
+				'args' => $args['args']['original_args'],
+			];
+			$regen_args = $this->main->data->validate_widget_data( $regen_args_input );
+
+			// Override the saved query args.
+			$args['args']['query_args'] = $regen_args['args']['query_args'];
+		}
+
 		// Modify the query args to include the new page.
 		$args['args']['query_args']['paged'] = $page;
 
@@ -360,8 +377,8 @@ class User_Home_Screen_Ajax {
 
 		$this->main->data->update_widgets_for_user( $user_widgets, $user );
 
-		$response             = new stdClass();
-		$response->message    = esc_html__( 'It appears to have worked', 'user-home-screen' );
+		$response          = new stdClass();
+		$response->message = esc_html__( 'It appears to have worked', 'user-home-screen' );
 
 		wp_send_json( $response );
 

--- a/languages/user-home-screen.pot
+++ b/languages/user-home-screen.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2016 Braad Martin, NerdWallet
+# Copyright (C) 2017 Braad Martin, NerdWallet
 # This file is distributed under the same license as the User Home Screen package.
 msgid ""
 msgstr ""
-"Project-Id-Version: User Home Screen 0.8.1\n"
+"Project-Id-Version: User Home Screen 0.8.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/user-home-screen\n"
-"POT-Creation-Date: 2016-11-16 23:30:43+00:00\n"
+"POT-Creation-Date: 2017-08-28 21:42:22+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 0.5.4\n"
@@ -189,7 +189,7 @@ msgstr ""
 #: inc/class-user-home-screen-ajax.php:205
 #: inc/class-user-home-screen-ajax.php:236
 #: inc/class-user-home-screen-ajax.php:277
-#: inc/class-user-home-screen-ajax.php:333
+#: inc/class-user-home-screen-ajax.php:350
 msgid "Sorry, you are missing a user."
 msgstr ""
 
@@ -198,8 +198,8 @@ msgstr ""
 #: inc/class-user-home-screen-ajax.php:185
 #: inc/class-user-home-screen-ajax.php:216
 #: inc/class-user-home-screen-ajax.php:257
-#: inc/class-user-home-screen-ajax.php:312
-#: inc/class-user-home-screen-ajax.php:364
+#: inc/class-user-home-screen-ajax.php:329
+#: inc/class-user-home-screen-ajax.php:381
 msgid "It appears to have worked"
 msgstr ""
 
@@ -212,11 +212,11 @@ msgid "Sorry, you are missing a widget ID, tab ID, or a page."
 msgstr ""
 
 #: inc/class-user-home-screen-ajax.php:299
-#: inc/class-user-home-screen-ajax.php:354
+#: inc/class-user-home-screen-ajax.php:371
 msgid "Sorry, the requested widget doesn't appear to exist."
 msgstr ""
 
-#: inc/class-user-home-screen-ajax.php:341
+#: inc/class-user-home-screen-ajax.php:358
 msgid "Sorry, you are missing a widget ID, tab ID, or a template parts array."
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-home-screen",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "Gruntfile.js",
   "author": "Braad Martin",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.nerdwallet.com
 Tags: user, home, screen, dashboard, widgets
 Requires at least: 4.5
 Tested up to: 4.7
-Stable tag: 0.8.1
+Stable tag: 0.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -44,6 +44,9 @@ Yes. This plugin has it's own way of registering and supporting custom widgets. 
 
 == Changelog ==
 
+= 0.8.2 =
+* Switch to forcing query_args to regenerate at render time on Post List widgets
+
 = 0.8.1 =
 * Stability fixes and UI polish.
 
@@ -51,6 +54,9 @@ Yes. This plugin has it's own way of registering and supporting custom widgets. 
 * Initial release.
 
 == Upgrade Notice ==
+
+= 0.8.2 =
+* Switch to forcing query_args to regenerate at render time on Post List widgets
 
 = 0.8.1 =
 * Stability fixes and UI polish.

--- a/user-home-screen.php
+++ b/user-home-screen.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: User Home Screen
- * Version:     0.8.1
+ * Version:     0.8.2
  * Description: A central admin dashboard that gives users an at-a-glance view into the content and data they care about most.
  * Author:      Braad Martin, NerdWallet
  * Author URI:  https://www.nerdwallet.com
@@ -10,7 +10,7 @@
  * @package User Home Screen
  */
 
-define( 'USER_HOME_SCREEN_VERSION', '0.8.1' );
+define( 'USER_HOME_SCREEN_VERSION', '0.8.2' );
 define( 'USER_HOME_SCREEN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'USER_HOME_SCREEN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
Originally when I was designing the widget data model I made the bad decision to save a `query_args` key in the DB with the derived query args from a given widgets raw input data.

Now in projects using this plugin I have a need to make backwards incompatible changes to `query_args`, but the current model assumes whatever comes from the DB is what should be used. We can pass the built value to a filter, but this doesn't let us easily modify things like nested `meta_query` and `tax_query` clauses, and really I'd prefer to head in the direction of `query_args` being 100% derived at query time, so I figured now is as good a time as any to make the switch.

With this change we simply regenerate `query_args` for Post List widgets whenever they are rendered, based on their original input args. All the existing filters are still in place and should continue to work. There are still existing filters to make further customizations at render time. The main change is that before passing `query_args` through the existing filters we refresh it with a call to the same validator function that creates it in the first place.